### PR TITLE
Add Notes field to MethodDoc type

### DIFF
--- a/httprouter-swugger.go
+++ b/httprouter-swugger.go
@@ -99,6 +99,9 @@ func (ws *WebService) AddRoute(method string, path string, function httprouter.H
 	if methodDoc.Doc != "" {
 		rb.Doc(methodDoc.Doc)
 	}
+	if methodDoc.Notes != "" {
+		rb.Notes(methodDoc.Notes)
+	}
 	if methodDoc.Writes != nil {
 		rb.Writes(methodDoc.Writes)
 	}

--- a/swugger-docs.go
+++ b/swugger-docs.go
@@ -9,6 +9,7 @@ type ServiceDoc struct {
 type MethodDoc struct {
 	Operation string
 	Doc string
+	Notes string
 	Params []ParamDoc
 	Reads interface{}
 	Writes interface{}


### PR DESCRIPTION
Add Notes field to MethodDoc type, which shows up in swagger-ui as an "Implementation Notes" section when you click on a method.
